### PR TITLE
Fix bug

### DIFF
--- a/OurGame/Engine/CollisionManager.cpp
+++ b/OurGame/Engine/CollisionManager.cpp
@@ -111,7 +111,6 @@ namespace hm
 							{
 								others[k]->GetCollider()->OnTriggerExit(gameObjects[l]->GetCollider());
 								gameObjects[l]->GetCollider()->OnTriggerExit(others[k]->GetCollider());
-
 							}
 							mColMap[id.id] = false;
 						}

--- a/OurGame/Engine/CollisionManager.h
+++ b/OurGame/Engine/CollisionManager.h
@@ -2,7 +2,7 @@
 #include "GameObject.h"
 namespace hm
 {
-	struct ColID
+	union ColID
 	{
 		bool operator> (const ColID& _other) const
 		{
@@ -19,13 +19,12 @@ namespace hm
 			return !(*this > _other);
 		}
 
-		union 
-		{
+		struct {
 			UINT32 first;
 			UINT32 second;
 		};
+		
 		UINT64 id;
-		bool bIsSort = false;
 	};
 	class CollisionManager
 	{


### PR DESCRIPTION
- OnTriggerEnter가 계속해서 호출되는 문제 해결
- 충돌 그룹을 관리하는 ColID를 유니온이 아닌 구조체로 생성했기 때문